### PR TITLE
Force negative values to be positive in HandPoseData._angle_to()

### DIFF
--- a/addons/hand_pose_detector/hand_pose_data.gd
+++ b/addons/hand_pose_detector/hand_pose_data.gd
@@ -214,4 +214,4 @@ static func _angle_to(from: Vector3, to: Vector3, axis : Vector3) -> float:
 	var to2 = to.slide(axis).normalized()
 
 	# Calculate the angle in degrees
-	return rad_to_deg(from2.signed_angle_to(to2, axis))
+	return abs(rad_to_deg(from2.signed_angle_to(to2, axis)))


### PR DESCRIPTION
Prevents issues with pose detection going from 1.0 to 0.0, making pose detection a lot more consistent

See my comment in https://github.com/Malcolmnixon/GodotXRHandPoseDetector/issues/24